### PR TITLE
Add ability to have multiple file path mappings to Vdebug

### DIFF
--- a/doc/Vdebug.txt
+++ b/doc/Vdebug.txt
@@ -724,8 +724,7 @@ default ptions look like this: >
     \    "on_close" : 'detach',
     \    "break_on_open" : 1,
     \    "ide_key" : '',
-    \    "remote_path" : "",
-    \    "local_path" : "",
+    \    "path_maps" : {},
     \    "debug_window_level" : 0,
     \    "debug_file_level" : 0,
     \    "debug_file" : "",
@@ -782,19 +781,12 @@ g:vdebug_options["ide_key"] (default = empty)
     restricts the connections to those that have a matching key. See
     |VdebugIDEKey| for more information.
 
-                                                   *VdebugOptions-remote_path*
-g:vdebug_options["remote_path"] (default = empty)  
+                                                       *VdebugOptions-path_maps*
+g:vdebug_options["path_maps"] (default = {})          
     This is only used for debugging a script on a remote machine. This is used
     to map remote file paths to local file paths, as they are very likely to be
-    different. Any file path specified here will be replaced by "local_path", 
-    so that the correct file is opened in the source window.
-
-                                                    *VdebugOptions-local_path*
-g:vdebug_options["local_path"] (default = empty)    
-    This is only used for debugging a script on a remote machine. This is used
-    to map local file paths to remote file paths, as they are very likely to be
-    different. Any file path specified here will be replaced by "remote_path"
-    before sending commands to the debugger engine.
+    different. This is a VimL dictionary of mappings between remote files (keys)
+    and local files (values).
 
                                             *VdebugOptions-debug_window_level*
 g:vdebug_options["debug_window_level"] (default = 0)    
@@ -905,13 +897,15 @@ Let's say we're debugging a file on a remote machine, and the path is
 /home/jon/php/myscript.php. I would have to set the remote and local path
 options as so: >
 
-    let g:vdebug_options['remote_path'] = "/home/user/scripts"
-    let g:vdebug_options['local_path'] = "/home/jon/php"
+    let g:vdebug_options['path_maps'] = {"/home/user/scripts": "/home/jon/php"}
 <
 When the debugger engine sends any file paths, a straight swap of the paths is
 done, so all instances of "/home/user/scripts" are replaced with
 "/home/jon/php". The opposite is done when sending file paths in the other
-direction. 
+direction.
+
+It is possible to have multiple file path mappings by adding more items in the
+"path_maps" dictionary.
 
 ------------------------------------------------------------------------------
 8.2 Connecting the two machines                       *VdebugRemoteConnection*

--- a/plugin/python/vdebug/util.py
+++ b/plugin/python/vdebug/util.py
@@ -56,14 +56,14 @@ class FilePath:
         Uses the "local_path" and "remote_path" options.
         """
         ret = f
-        if vdebug.opts.Options.isset('remote_path'):
-            rp = vdebug.opts.Options.get('remote_path')
-            lp = vdebug.opts.Options.get('local_path')
-            vdebug.log.Log("Replacing remote path (%s) " % rp +\
-                    "with local path (%s)" % lp,\
-                    vdebug.log.Logger.DEBUG)
-            if ret.startswith(rp):
-                ret = ret.replace(rp,lp)
+        if vdebug.opts.Options.isset('path_maps'):
+            for remote, local in vdebug.opts.Options.get('path_maps', dict).items():
+                if ret.startswith(remote):
+                    vdebug.log.Log("Replacing remote path (%s) " % remote +\
+                            "with local path (%s)" % local ,\
+                            vdebug.log.Logger.DEBUG)
+                    ret = ret.replace(remote,local)
+                    break
         return ret
 
     def _create_remote(self,f):
@@ -72,14 +72,15 @@ class FilePath:
         Uses the "local_path" and "remote_path" options.
         """
         ret = f
-        if vdebug.opts.Options.isset('remote_path'):
-            rp = vdebug.opts.Options.get('remote_path')
-            lp = vdebug.opts.Options.get('local_path')
-            vdebug.log.Log("Replacing local path (%s) " % rp +\
-                    "with remote path (%s)" % lp,\
-                    vdebug.log.Logger.DEBUG)
-            if ret.startswith(lp):
-                ret = ret.replace(lp,rp)
+
+        if vdebug.opts.Options.isset('path_maps'):
+            for remote, local in vdebug.opts.Options.get('path_maps', dict).items():
+                if ret.startswith(local):
+                    vdebug.log.Log("Replacing local path (%s) " % local +\
+                            "with remote path (%s)" % remote ,\
+                            vdebug.log.Logger.DEBUG)
+                    ret = ret.replace(local,remote)
+                    break
         return ret
 
     def as_local(self):

--- a/plugin/vdebug.vim
+++ b/plugin/vdebug.vim
@@ -72,8 +72,7 @@ let g:vdebug_options_defaults = {
 \    "debug_window_level" : 0,
 \    "debug_file_level" : 0,
 \    "debug_file" : "",
-\    "remote_path" : "",
-\    "local_path" : "",
+\    "path_maps" : {},
 \    "watch_window_style" : 'expanded',
 \}
 

--- a/tests/test_util_filepath.py
+++ b/tests/test_util_filepath.py
@@ -8,7 +8,7 @@ from vdebug.util import FilePath,FilePathError
 class LocalFilePathTest(unittest.TestCase):
 
     def setUp(self):
-        vdebug.opts.Options.set({'local_path':'','remote_path':''})
+        vdebug.opts.Options.set({'path_maps':{}})
 
     def test_as_local(self):
         filename = "/home/user/some/path"
@@ -69,15 +69,22 @@ class LocalFilePathTest(unittest.TestCase):
 
 def RemotePathTest(self):
     def setUp(self):
-        map = {"remote_path":"/remote/","local_path":"/local/"}
-        vdebug.opts.Options.set(map)
+        vdebug.opts.Options.set({'path_maps':{'/remote1/':'/local1/', '/remote2/':'/local2'}})
 
     def test_as_local(self):
-        filename = "/remote/path/to/file"
+        filename = "/remote1/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("/local/path/to/file",file)
+        self.assertEqual("/local1/path/to/file",file)
+
+        filename = "/remote2/path/to/file"
+        file = FilePath(filename)
+        self.assertEqual("/local2/path/to/file",file)
 
     def test_as_remote(self):
-        filename = "/local/path/to/file"
+        filename = "/local1/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("/remote/path/to/file",file)
+        self.assertEqual("/remote1/path/to/file",file)
+
+        filename = "/local2/path/to/file"
+        file = FilePath(filename)
+        self.assertEqual("/remote2/path/to/file",file)


### PR DESCRIPTION
This commit adds the ability to have multiple file path mappings to Vdebug. I found it necessary during my work and thought I should contribute the patch to community. Attached are: functional patch, unit tests patch, documentation patch.
