### PR TITLE
Continuous mode: parse option as an int

### DIFF
--- a/plugin/python/vdebug/runner.py
+++ b/plugin/python/vdebug/runner.py
@@ -79,7 +79,7 @@ class Runner:
                 self.ui.statuswin.set_status("stopped")
                 self.ui.say("Debugging session has ended")
                 self.close_connection(False)
-                if vdebug.opts.Options.get('continuous_mode',bool):
+                if vdebug.opts.Options.get('continuous_mode', int) != 0:
                     self.open()
                     return
             else:


### PR DESCRIPTION
I had to apply this patch to  respect my settings:

``` vim
let g:vdebug_options= {
....
\    "continuous_mode" : 0,
\}
```
