### PR TITLE
Fix bug: Remapping won't work for mappings of single modes.

### DIFF
--- a/plugin/python/vdebug/util.py
+++ b/plugin/python/vdebug/util.py
@@ -55,7 +55,18 @@ class Keymapper:
             for mapping in self.existing:
                 vdebug.log.Log("Remapping key with '%s' " % mapping,\
                         vdebug.log.Logger.DEBUG)
-                vim.command("noremap %s" % mapping)
+                regex = re.compile(r'\s+')
+                parts = regex.split(mapping)
+                mapcmd = 'noremap'
+                if len(parts)>2:
+                    modeRegex = re.compile(r'^[nvsxoilc!]$')
+                    if modeRegex.match(parts[0]):
+                        mapping = ' '.join(parts[1:])
+                        if parts[0]=='!':
+                            mapcmd = 'noremap!'
+                        else:
+                            mapcmd = '%snoremap' % parts[0]
+                vim.command("%s %s" % (mapcmd,mapping))
 
 class FilePath:
     is_win = False


### PR DESCRIPTION
Mappings created with nmap,imap and alike will display a mode character at the beginning of the string listed by noremap, this will cause the restoring of original mappings fail.

See ':h map-listing' for more info.
