### PR TITLE
Fix winminheight error: E591: 'winheight' cannot be smaller than 'winminheight': winheight=5

### DIFF
--- a/plugin/python/vdebug/ui/vimui.py
+++ b/plugin/python/vdebug/ui/vimui.py
@@ -270,6 +270,9 @@ class Window(vdebug.ui.interface.Window):
         return int(vim.eval("bufwinnr('"+self.name+"')"))
 
     def set_height(self,height):
+        minheight  =  vim.eval("&winminheight")
+        if height < minheight:
+            height  =  minheight
         self.command('set winheight=%s' % str(height))
 
     def write(self, msg, return_focus = True, after = "normal G"):


### PR DESCRIPTION
```
E591: 'winheight' cannot be smaller than 'winminheight': winheight=5
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/link/zhaocai/vim/bundle/vdebug/plugin/python/start_vdebug.py", line 31, in run
    self.runner.run()
  File "/link/zhaocai/vim/bundle/vdebug/plugin/python/vdebug/runner.py", line 160, in run
    self.open()
  File "/link/zhaocai/vim/bundle/vdebug/plugin/python/vdebug/runner.py", line 47, in open
    self.ui.open()
  File "/link/zhaocai/vim/bundle/vdebug/plugin/python/vdebug/ui/vimui.py", line 62, in open
    self.statuswin.set_height(5)
  File "/link/zhaocai/vim/bundle/vdebug/plugin/python/vdebug/ui/vimui.py", line 273, in set_height
    self.command('set winheight=%s' % str(height))
  File "/link/zhaocai/vim/bundle/vdebug/plugin/python/vdebug/ui/vimui.py", line 355, in command
    vim.command(cmd)
vim.error         
```
