### PR TITLE
Fix window destruction

### DIFF
--- a/plugin/python/vdebug/ui/vimui.py
+++ b/plugin/python/vdebug/ui/vimui.py
@@ -163,13 +163,6 @@ class Ui(vdebug.ui.interface.Ui):
             return
         self.is_open = False
 
-        if self.watchwin:
-            self.watchwin.destroy()
-        if self.stackwin:
-            self.stackwin.destroy()
-        if self.statuswin:
-            self.statuswin.destroy()
-
         vdebug.log.Log.remove_logger('WindowLogger')
         if self.tabnr:
             vim.command('silent! '+self.tabnr+'tabc!')
@@ -178,6 +171,13 @@ class Ui(vdebug.ui.interface.Ui):
 
         if self.empty_buf_num:
             vim.command('bw' + self.empty_buf_num)
+
+        if self.watchwin:
+            self.watchwin.destroy()
+        if self.stackwin:
+            self.stackwin.destroy()
+        if self.statuswin:
+            self.statuswin.destroy()
 
         self.watchwin = None
         self.stackwin = None


### PR DESCRIPTION
Using F6 to close the debugger tab caused the message `E855: Autocommands caused command to abort` and sometimes caused a `vim.error`:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "F:\Settings\home\.vim\vundle\vdebug\plugin/python/start_vdebug.py", line 171, in close
    self.runner.close()
  File "F:\Settings\home\.vim\vundle\vdebug\plugin/python\vdebug\runner.py", line 338, in close
    self.ui.close()
  File "F:\Settings\home\.vim\vundle\vdebug\plugin/python\vdebug\ui\vimui.py", line 165, in close
    self.statuswin.destroy()
  File "F:\Settings\home\.vim\vundle\vdebug\plugin/python\vdebug\ui\vimui.py", line 335, in destroy
    self.command('bwipeout ' + self.name)
  File "F:\Settings\home\.vim\vundle\vdebug\plugin/python\vdebug\ui\vimui.py", line 346, in command
    vim.command(cmd)
vim.error
```

This fixes these issues. I assume the problem was related to the fact that the last window in the tab was being closed.
