### PR TITLE
Fix error message on plugin reload

### DIFF
--- a/plugin/vdebug.vim
+++ b/plugin/vdebug.vim
@@ -156,7 +156,7 @@ function! vdebug:get_visual_selection()
   return join(lines, "\n")
 endfunction
 
-function vdebug:edit(filename)
+function! vdebug:edit(filename)
     try
         execute 'buffer' fnameescape(a:filename)
     catch /^Vim\%((\a\+)\)\=:E94/


### PR DESCRIPTION
When reloading Vdebug (ie as a result of a :BundleUpdate in Vundle) the following error message was being displayed:

```
Error detected while processing /home/$USER/.vim/bundle/vdebug/plugin/vdebug.vim:
line  165:
E122: Function vdebug:edit already exists, add ! to replace it 
```

This fixes that.
