### PR TITLE
InputStream.probe: sleep for 100ms after getchar()

### DIFF
--- a/plugin/python/vdebug/util.py
+++ b/plugin/python/vdebug/util.py
@@ -4,6 +4,7 @@ import vim
 import re
 import os
 import urllib
+import time
 
 class Keymapper:
     """Map and unmap key commands for the Vim user interface.
@@ -198,6 +199,7 @@ class InputStream:
     def probe(self):
         try:
             vim.eval("getchar(0)")
+            time.sleep(0.1)
         except: # vim.error
             raise UserInterrupt()
 


### PR DESCRIPTION
Without sleeping here, all CPU is consumed during polling.
