### PR TITLE
Point Debian/Ubuntu users to the vim-nox package

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ where the path supplied is vdebug's doc directory. This should enable vdebug's h
 
 **Requirements**:
 
-  * Vim compiled with Python 2.6+ support, tabs and signs
+  * Vim compiled with Python 2.6+ support, tabs and signs (for Debian/Ubuntu this is provided in the vim-nox package)
   * A programming language that has a DBGP debugger, e.g. PHP, Python, Ruby,
     Perl, NodeJS, Tcl...
 


### PR DESCRIPTION
Please consider this documentation patch to make it easier for Debian & Ubuntu users to install vdebug. Took me a while to figure this out myself...
