### PR TITLE
Sort path maps by remote path length

### DIFF
--- a/plugin/python/vdebug/util.py
+++ b/plugin/python/vdebug/util.py
@@ -106,7 +106,8 @@ class FilePath:
             ret = ret.replace("/","\\")
 
         if vdebug.opts.Options.isset('path_maps'):
-            for remote, local in vdebug.opts.Options.get('path_maps', dict).items():
+            sorted_path_maps = sorted(vdebug.opts.Options.get('path_maps', dict).iteritems(), key=lambda l: len(l[0]), reverse=True)
+            for remote, local in sorted_path_maps:
                 if remote in ret:
                     vdebug.log.Log("Replacing remote path (%s) " % remote +\
                             "with local path (%s)" % local ,\
@@ -123,7 +124,8 @@ class FilePath:
         ret = f
 
         if vdebug.opts.Options.isset('path_maps'):
-            for remote, local in vdebug.opts.Options.get('path_maps', dict).items():
+            sorted_path_maps = sorted(vdebug.opts.Options.get('path_maps', dict).iteritems(), key=lambda l: len(l[0]), reverse=True)
+            for remote, local in sorted_path_maps:
                 if local in ret:
                     vdebug.log.Log("Replacing local path (%s) " % local +\
                             "with remote path (%s)" % remote ,\


### PR DESCRIPTION
When there are path maps defined for a directory and a subdirectory it
is necessary to use the best match. For example, if there is a mapping
like

```
path_maps = {
    "/var/www/foo"                : "/home/user/projects/foo",
    "/var/www/foo/include/libbar" : "/home/user/projects/bar"
}
```

a request for `/var/www/foo/include/libbar/file.php` matches both maps
defined above. Since `path_maps` is an unordered dictionary there is no
way to know what the result of the translation will be. Therefore it is
better to iterate over the dictionary in a well defined order starting
with the most specific, i.e. longest path.
