### PR TITLE
Change function names to adhere stricter rules

### DIFF
--- a/plugin/python/vdebug/event.py
+++ b/plugin/python/vdebug/event.py
@@ -60,7 +60,7 @@ class VisualEvalEvent(Event):
     """Evaluate a block of code given by visual selection in Vim.
     """
     def execute(self,runner):
-        selection = vim.eval("vdebug:get_visual_selection()")
+        selection = vim.eval("Vdebug_get_visual_selection()")
         runner.eval(selection)
         return True
 

--- a/plugin/python/vdebug/ui/vimui.py
+++ b/plugin/python/vdebug/ui/vimui.py
@@ -42,7 +42,7 @@ class Ui(vdebug.ui.interface.Ui):
             vim.command('silent tabnew')
             self.empty_buf_num = vim.eval('bufnr("%")')
             if existing_buffer:
-                vim.command('call vdebug:edit("%s")' % cur_buf_name)
+                vim.command('call Vdebug_edit("%s")' % cur_buf_name)
 
             self.tabnr = vim.eval("tabpagenr()")
 
@@ -230,7 +230,7 @@ class SourceWindow(vdebug.ui.interface.Window):
         self.file = file
         vdebug.log.Log("Setting source file: "+file,vdebug.log.Logger.INFO)
         self.focus()
-        vim.command('call vdebug:edit("%s")' % str(file).replace("\\", "\\\\"))
+        vim.command('call Vdebug_edit("%s")' % str(file).replace("\\", "\\\\"))
 
     def set_line(self,lineno):
         self.focus()

--- a/plugin/vdebug.vim
+++ b/plugin/vdebug.vim
@@ -148,7 +148,7 @@ function! s:OptionNames(A,L,P)
     endif
 endfunction
 
-function! vdebug:get_visual_selection()
+function! Vdebug_get_visual_selection()
   let [lnum1, col1] = getpos("'<")[1:2]
   let [lnum2, col2] = getpos("'>")[1:2]
   let lines = getline(lnum1, lnum2)
@@ -157,7 +157,7 @@ function! vdebug:get_visual_selection()
   return join(lines, "\n")
 endfunction
 
-function! vdebug:edit(filename)
+function! Vdebug_edit(filename)
     try
         execute 'buffer' fnameescape(a:filename)
     catch /^Vim\%((\a\+)\)\=:E94/


### PR DESCRIPTION
Since v7.4.260 there were some changes done to be more strict about what
can be used in function names. This change makes Vdebug follow these new
rules.

This resolves #155

Signed-off-by: BlackEagle ike.devolder@gmail.com
