### PR TITLE
Support communication with the debugged process over UNIX-domain sockets

### DIFF
--- a/doc/Vdebug.txt
+++ b/doc/Vdebug.txt
@@ -785,8 +785,10 @@ retain option settings by adding them to your vimrc.
 
 The default options look like this: >
     let g:vdebug_options= {
+    \    "socket_type": "tcp",
     \    "port" : 9000,
     \    "server" : 'localhost',
+    \    "unix_permissions": 0700,
     \    "timeout" : 20,
     \    "on_close" : 'detach',
     \    "break_on_open" : 1,
@@ -810,6 +812,13 @@ if you don't set them.
 
 Here is a list of all the available options.
 
+                                                   *VdebugOptions-socket_type*
+g:vdebug_options["socket_type"] (default = "tcp")
+    This sets whether Vdebug waits over a TCP or an Unix-domain
+    socket. When set to "tcp" the listening address is configured via
+    the port and server options, when set to "unix" the listening path
+    is configured via the unix_path option.
+
                                                           *VdebugOptions-port*
 g:vdebug_options["port"] (default = 9000)                 
     This sets the port that Vdebug will use to listen for connections. Xdebug
@@ -822,6 +831,16 @@ g:vdebug_options["server"] (default = "localhost")
     defaults to localhost, as it assumes that the debugger engine will be
     running on the same machine and also connecting to localhost. If you want
     to debug a script on a different machine, look at |VdebugRemote|.
+
+                                                     *VdebugOptions-unix_path*
+g:vdebug_options["unix_path"] (default = empty)
+    This sets the path that Vdebug will use to listen for connections
+    when listening over an Unix-domain socket.
+
+                                              *VdebugOptions-unix_permissions*
+g:vdebug_options["unix_permissions"] (default = 0700)
+    This sets the permissions of the Unix-domain socket that Vdebug
+    will use to listen for connections.
 
                                                        *VdebugOptions-timeout*
 g:vdebug_options["timeout"] (default = 20)             

--- a/plugin/python/vdebug/runner.py
+++ b/plugin/python/vdebug/runner.py
@@ -16,6 +16,14 @@ class Runner:
     an interface that Vim can use to send commands.
     """
 
+    ENDPOINT_ARGS = [
+        ('socket_type', str),
+        ('server', str),
+        ('port', int),
+        ('unix_path', str),
+        ('unix_group', str),
+        ('unix_permissions', int),
+    ]
     def __init__(self):
         self.api = None
         vdebug.opts.Options.set(vim.eval('g:vdebug_options'))
@@ -39,21 +47,23 @@ class Runner:
                 vdebug.log.Log.set_logger(vdebug.log.FileLogger(\
                         vdebug.opts.Options.get('debug_file_level'),\
                         vdebug.opts.Options.get('debug_file')))
+            endpoint = {}
+            for arg, pytype in Runner.ENDPOINT_ARGS:
+                if vdebug.opts.Options.isset(arg):
+                    endpoint[arg] = vdebug.opts.Options.get(arg, pytype)
             self.listen(\
-                    vdebug.opts.Options.get('server'),\
-                    vdebug.opts.Options.get('port',int),\
+                    endpoint,\
                     vdebug.opts.Options.get('timeout',int))
 
             self.ui.open()
             self.keymapper.map()
             self.ui.set_listener_details(\
-                    vdebug.opts.Options.get('server'),\
-                    vdebug.opts.Options.get('port'),\
+                    self.api.conn.address_description(),\
                     vdebug.opts.Options.get('ide_key'))
 
-            addr = self.api.conn.address
-            vdebug.log.Log("Found connection from " + str(addr),vdebug.log.Logger.INFO)
-            self.ui.set_conn_details(addr[0],addr[1])
+            addr = self.api.conn.peer_description()
+            vdebug.log.Log("Found connection from " + addr,vdebug.log.Logger.INFO)
+            self.ui.set_conn_details(addr)
 
             self.set_features()
             self.breakpoints.update_lines(self.ui.get_breakpoint_sign_positions())
@@ -253,7 +263,7 @@ class Runner:
         self.api.breakpoint_set(bp.get_cmd())
         self.run()
 
-    def listen(self,server,port,timeout):
+    def listen(self,endpoint,timeout):
         """Open the vdebug.dbgp API with connection.
 
         Uses existing connection if possible.
@@ -269,8 +279,8 @@ class Runner:
                 check_ide_key = True
                 if len(ide_key) == 0:
                     check_ide_key = False
-                    
-                connection = vdebug.dbgp.Connection(server,port,\
+
+                connection = vdebug.dbgp.Connection(endpoint,
                         timeout,vdebug.util.InputStream())
 
                 self.api = vdebug.dbgp.Api(connection)

--- a/plugin/python/vdebug/ui/vimui.py
+++ b/plugin/python/vdebug/ui/vimui.py
@@ -87,14 +87,14 @@ class Ui(vdebug.ui.interface.Ui):
                 self.statuswin.set_status("stopped")
                 self.remove_conn_details()
 
-    def set_conn_details(self,addr,port):
-        self.statuswin.insert("Connected to %s:%s" %(addr,port),2,True)
+    def set_conn_details(self,description):
+        self.statuswin.insert("Connected to %s" %(description),2,True)
 
     def remove_conn_details(self):
         self.statuswin.insert("Not connected",2,True)
 
-    def set_listener_details(self,addr,port,idekey):
-        details = "Listening on %s:%s" %(addr,port)
+    def set_listener_details(self,description,idekey):
+        details = "Listening on %s" %(description)
         if len(idekey):
             details += " (IDE key: %s)" % idekey
         self.statuswin.insert(details,1,True)

--- a/plugin/vdebug.vim
+++ b/plugin/vdebug.vim
@@ -83,9 +83,11 @@ let g:vdebug_keymap_defaults = {
 \}
 
 let g:vdebug_options_defaults = {
+\    "socket_type": "tcp",
 \    "port" : 9000,
 \    "timeout" : 20,
 \    "server" : 'localhost',
+\    "unix_permissions": 0700,
 \    "on_close" : 'detach',
 \    "break_on_open" : 1,
 \    "ide_key" : '',


### PR DESCRIPTION
I'd like to add the option for the debugger to listen on an Unix-domain socket, to avoid having a TCP port open by the debugger on a shared server (I can restrict access to the Unix-domain socket via Unix permissions).

The patch also updates the documentation.
