### PR TITLE
Make Vdebug fully async - don't block VIM while stepping or running

### DIFF
--- a/features/step_definitions/php_steps.rb
+++ b/features/step_definitions/php_steps.rb
@@ -2,5 +2,11 @@ Given "I start the debugger with the PHP script $script" do |script|
   vdebug.start_listening
   full_script_path = Dir.getwd + "/" + script
   run_php_script full_script_path
+  (1..15).each do |n|
+    if vdebug.running?
+      break
+    end
+    sleep 1
+  end
   vdebug.running?.should be(true), "Error, vdebug is not running\nVIM messages: #{vdebug.messages}"
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -13,6 +13,7 @@ Before do
 end
 
 After do
+  vdebug.close
   kill_vim
   Dir.chdir '..'
   system "rm -r tmpspace"

--- a/plugin/python/vdebug/connection.py
+++ b/plugin/python/vdebug/connection.py
@@ -68,15 +68,20 @@ class ConnectionHandler:
             body = body + buf
         return body
 
-    def recv_msg(self):
+    def recv_msg(self, timeout = None):
         """Receive a message from the debugger.
 
         Returns a string, which is expected to be XML.
         """
-        length = self.__recv_length()
-        body     = self.__recv_body(length)
-        self.__recv_null()
-        return body
+        self.sock.settimeout(timeout)
+        try:
+            length = self.__recv_length()
+            body   = self.__recv_body(length)
+            self.__recv_null()
+            return body
+        finally:
+            if self.sock != None:
+                self.sock.settimeout(None)
 
     def send_msg(self, cmd):
         """Send a message to the debugger.

--- a/plugin/python/vdebug/dbgp.py
+++ b/plugin/python/vdebug/dbgp.py
@@ -340,6 +340,11 @@ class Api:
         """
         return self.send_cmd('step_out','',StatusResponse, 1)
 
+    def break_async(self):
+        """Tell the debugger to asynchronously break
+        """
+        return self.send_cmd('break','',StatusResponse, 1)
+
     def stop(self):
         """Tell the debugger to stop execution.
 

--- a/plugin/python/vdebug/debugger_interface.py
+++ b/plugin/python/vdebug/debugger_interface.py
@@ -44,6 +44,11 @@ class DebuggerInterface:
         """
         self.session_handler.run()
 
+    def break_async(self):
+        """Tell the debugger to break
+        """
+        self.session_handler.dispatch_event("break_async")
+
     def run_to_cursor(self):
         """Run to the current VIM cursor position.
         """

--- a/plugin/python/vdebug/debugger_interface.py
+++ b/plugin/python/vdebug/debugger_interface.py
@@ -33,8 +33,8 @@ class DebuggerInterface:
     def status_for_statusline(self):
         return self.session_handler.status_for_statusline()
 
-    def start_if_ready(self):
-        self.session_handler.start_if_ready()
+    def handle_periodically(self):
+        return self.session_handler.periodically()
 
     def listen(self):
         self.session_handler.listen()

--- a/plugin/python/vdebug/event.py
+++ b/plugin/python/vdebug/event.py
@@ -288,6 +288,12 @@ class RunEvent(Event):
         else:
             self.dispatch("listen")
 
+class AsyncBreakEvent(Event):
+    def run(self):
+        vdebug.log.Log("Breaking")
+        res = self.api.break_async()
+        self.dispatch("refresh", res)
+
 class ListenEvent(Event):
     def run(self):
         self.session_handler.listen()
@@ -397,6 +403,7 @@ class StopWaitingEvent(Event):
 class Dispatcher:
     events = {
         "run": RunEvent,
+        "break_async": AsyncBreakEvent,
         "refresh": RefreshEvent,
         "listen": ListenEvent,
         "step_over": StepOverEvent,

--- a/plugin/python/vdebug/event.py
+++ b/plugin/python/vdebug/event.py
@@ -234,6 +234,12 @@ class EventError(Exception):
 
 class RefreshEvent(Event):
     def run(self, status):
+        if status == None:
+            self.dispatch("start_waiting")
+            return
+        else:
+            self.dispatch("stop_waiting")
+
         if str(status) == "interactive":
             self.ui.error("Debugger engine says it is in interactive mode,"+\
                     "which is not supported: closing connection")
@@ -380,6 +386,14 @@ class ReloadKeymappingsEvent(Event):
             print "Reloaded keymappings"
             self.session.keymapper().reload()
 
+class StartWaitingEvent(Event):
+    def run(self):
+        self.session_handler.start_waiting()
+
+class StopWaitingEvent(Event):
+    def run(self):
+        self.session_handler.stop_waiting()
+
 class Dispatcher:
     events = {
         "run": RunEvent,
@@ -393,7 +407,9 @@ class Dispatcher:
         "set_breakpoint": SetBreakpointEvent,
         "get_context": GetContextEvent,
         "reload_keymappings": ReloadKeymappingsEvent,
-        "remove_breakpoint": RemoveBreakpointEvent
+        "remove_breakpoint": RemoveBreakpointEvent,
+        "start_waiting": StartWaitingEvent,
+        "stop_waiting": StopWaitingEvent
     }
 
     def __init__(self, session_handler):

--- a/plugin/python/vdebug/listener.py
+++ b/plugin/python/vdebug/listener.py
@@ -43,16 +43,10 @@ class BackgroundListener:
         self.__server = vdebug.connection.SocketServer()
 
     def start(self):
-        if vdebug.opts.Options.get("auto_start", int):
-            vim.command('au CursorHold * python debugger.start_if_ready()')
-            vim.command('au CursorMoved * python debugger.start_if_ready()')
         self.__server.start(vdebug.opts.Options.get('server'),
                             vdebug.opts.Options.get('port', int))
 
     def stop(self):
-        if vdebug.opts.Options.get("auto_start", bool):
-            vim.command('au! CursorHold *')
-            vim.command('au! CursorMoved *')
         self.__server.stop()
 
     def status(self):

--- a/plugin/python/vdebug/ui/vimui.py
+++ b/plugin/python/vdebug/ui/vimui.py
@@ -581,6 +581,7 @@ class WatchWindow(Window):
 
 class StatusWindow(Window):
     name = "DebuggerStatus"
+    status = None
 
     def on_create(self):
         self.command('setlocal syntax=debugger_status')
@@ -601,6 +602,13 @@ class StatusWindow(Window):
 
     def set_conn_details(self, addr, port):
         self.insert("Connected to %s:%s" %(addr, port), 2, True)
+
+    def set_status(self,status):
+        self.insert("Status: "+str(status),0,True)
+        self.status = status
+
+    def get_status(self):
+        return self.status
 
     def set_listener_details(self, addr, port, idekey):
         details = "Listening on %s:%s" %(addr, port)

--- a/plugin/vdebug.vim
+++ b/plugin/vdebug.vim
@@ -74,6 +74,7 @@ let g:vdebug_keymap_defaults = {
 \    "step_over" : "<F2>",
 \    "step_into" : "<F3>",
 \    "step_out" : "<F4>",
+\    "break_async" : "<F8>",
 \    "close" : "<F6>",
 \    "detach" : "<F7>",
 \    "set_breakpoint" : "<F10>",

--- a/rubylib/vdebug.rb
+++ b/rubylib/vdebug.rb
@@ -9,9 +9,10 @@ class Vdebug
 
   def start_listening
     clear_buffer_cache!
-    vim.command "VdebugOpt background_listener 0"
+    #vim.command "VdebugOpt background_listener 0"
     vim.server.remote_send ":python debugger.run()<CR>"
     sleep 1
+    vim.command "python debugger.handle_periodically()"
   end
 
   def messages
@@ -48,6 +49,7 @@ class Vdebug
 
   # Has the vdebug GUI been opened?
   def gui_open?
+    vim.command "python debugger.handle_periodically()"
     names = buffers.values
     %w[DebuggerStack DebuggerStatus DebuggerWatch].all? { |b|
       names.include? b
@@ -59,10 +61,11 @@ class Vdebug
   end
 
   def connected?
-     status = vim.command(
-       "python print debugger.status()"
-     )
-     %w(break running).include? status
+    vim.command "python debugger.handle_periodically()"
+    status = vim.command(
+      "python print debugger.status()"
+    )
+    %w(break running).include? status
   end
 
   def watch_window_content
@@ -102,6 +105,10 @@ class Vdebug
 
   def status
     /Status: (\S+)/.match(status_window_content)[1]
+  end
+
+  def close
+    vim.command 'python debugger.close()'
   end
 
 protected

--- a/spec/vdebug_spec.rb
+++ b/spec/vdebug_spec.rb
@@ -6,6 +6,10 @@ describe Vdebug do
     @vimserver = double("vimserver")
     @vim = double("vim", server: @vimserver)
     @vdebug = Vdebug.new vim
+
+    vim.should_receive(:command).
+      with("python debugger.handle_periodically()").
+      at_most(:once)
   end
 
   let(:vimrunner) { @vim }
@@ -37,22 +41,26 @@ describe Vdebug do
     context "asking whether it's connected" do
       it "should query the vdebug api" do
         vim.should_receive(:command).
-          with("python print debugger.runner.is_alive()").
+          with("python print debugger.status()").
           and_return("True")
         vdebug.connected?
       end
 
-      context "when the vdebug api returns 'False'" do
+      context "when the vdebug api returns 'inactive'" do
         before do
-          vim.should_receive(:command).and_return("False")
+          vim.should_receive(:command).
+            with("python print debugger.status()").
+            and_return("inactive")
         end
         subject { vdebug.connected? }
         it { should be false }
       end
 
-      context "when the vdebug api returns 'True'" do
+      context "when the vdebug api returns 'break'" do
         before do
-          vim.should_receive(:command).and_return("True")
+          vim.should_receive(:command).
+            with("python print debugger.status()").
+            and_return("break")
         end
         subject { vdebug.connected? }
         it { should be true }

--- a/tests/test_dbgp_api.py
+++ b/tests/test_dbgp_api.py
@@ -4,6 +4,7 @@ if __name__ == "__main__":
 import unittest2 as unittest
 import vdebug.dbgp
 from mock import MagicMock, patch
+import socket
 
 class ApiTest(unittest.TestCase):      
     """Test the Api class in the vdebug.dbgp module."""
@@ -69,22 +70,14 @@ class ApiTest(unittest.TestCase):
         status_res = self.p.run()
         assert str(status_res) == "running"
 
+    def test_run_async_retval(self):
+        """Test that the run command returns None if running doesn't return before the timeout expires."""
+        self.p.conn.recv_msg.side_effect = socket.timeout
+        status_res = self.p.run()
+        assert status_res == None
+
     def test_step_into_retval(self):
         """Test that the step_into command receives a message from the api."""
-        self.p.conn.recv_msg.return_value = """<?xml
-            version="1.0" encoding="iso-8859-1"?>\n
-            <response command="step_into"
-                      xmlns="urn:debugger_api_v1"
-                      status="break"
-                      reason="ok"
-                      transaction_id="transaction_id">
-                message data
-            </response>"""
-        status_res = self.p.step_out()
-        assert str(status_res) == "break"
-
-    def test_step_over_retval(self):
-        """Test that the step_over command receives a message from the api."""
         self.p.conn.recv_msg.return_value = """<?xml
             version="1.0" encoding="iso-8859-1"?>\n
             <response command="step_into"
@@ -97,8 +90,14 @@ class ApiTest(unittest.TestCase):
         status_res = self.p.step_into()
         assert str(status_res) == "break"
 
-    def test_step_out_retval(self):
-        """Test that the step_out command receives a message from the api."""
+    def test_step_into_async_retval(self):
+        """Test that the step_info command returns None if stepping doesn't return before the timeout expires."""
+        self.p.conn.recv_msg.side_effect = socket.timeout
+        status_res = self.p.step_into()
+        assert status_res == None
+
+    def test_step_over_retval(self):
+        """Test that the step_over command receives a message from the api."""
         self.p.conn.recv_msg.return_value = """<?xml
             version="1.0" encoding="iso-8859-1"?>\n
             <response command="step_into"
@@ -110,6 +109,32 @@ class ApiTest(unittest.TestCase):
             </response>"""
         status_res = self.p.step_over()
         assert str(status_res) == "break"
+
+    def test_step_over_async_retval(self):
+        """Test that the step_over command returns None if stepping doesn't return before the timeout expires."""
+        self.p.conn.recv_msg.side_effect = socket.timeout
+        status_res = self.p.step_over()
+        assert status_res == None
+
+    def test_step_out_retval(self):
+        """Test that the step_out command receives a message from the api."""
+        self.p.conn.recv_msg.return_value = """<?xml
+            version="1.0" encoding="iso-8859-1"?>\n
+            <response command="step_into"
+                      xmlns="urn:debugger_api_v1"
+                      status="break"
+                      reason="ok"
+                      transaction_id="transaction_id">
+                message data
+            </response>"""
+        status_res = self.p.step_out()
+        assert str(status_res) == "break"
+
+    def test_step_out_async_retval(self):
+        """Test that the step_out command returns None if stepping doesn't return before the timeout expires."""
+        self.p.conn.recv_msg.side_effect = socket.timeout
+        status_res = self.p.step_out()
+        assert status_res == None
 
     def test_stop_retval(self):
         """Test that the stop command receives a message from the api."""

--- a/tests/test_dbgp_api.py
+++ b/tests/test_dbgp_api.py
@@ -80,7 +80,7 @@ class ApiTest(unittest.TestCase):
                       transaction_id="transaction_id">
                 message data
             </response>"""
-        status_res = self.p.run()
+        status_res = self.p.step_out()
         assert str(status_res) == "break"
 
     def test_step_over_retval(self):
@@ -94,7 +94,7 @@ class ApiTest(unittest.TestCase):
                       transaction_id="transaction_id">
                 message data
             </response>"""
-        status_res = self.p.run()
+        status_res = self.p.step_into()
         assert str(status_res) == "break"
 
     def test_step_out_retval(self):
@@ -108,7 +108,7 @@ class ApiTest(unittest.TestCase):
                       transaction_id="transaction_id">
                 message data
             </response>"""
-        status_res = self.p.run()
+        status_res = self.p.step_over()
         assert str(status_res) == "break"
 
     def test_stop_retval(self):

--- a/tests/test_dbgp_connection.py
+++ b/tests/test_dbgp_connection.py
@@ -11,8 +11,12 @@ class SocketMock():
     def __init__(self):
         self.response = []
         self.last_msg = None
+        self.timeouts = []
+        self.exception = None
 
     def recv(self,length):
+        if(self.exception != None):
+            raise self.exception
         ret = self.response[0]
         if len(ret) >= length:
             chars = ret[0:length]
@@ -31,11 +35,20 @@ class SocketMock():
         self.response.append(list(res))
         self.response.append(['\0'])
 
+    def add_raise(self,exception):
+        self.exception = exception
+
     def send(self,msg):
         self.last_msg = msg
 
+    def settimeout(self,timeout):
+        self.timeouts.append(timeout)
+
     def get_last_sent(self):
         return self.last_msg
+
+    def get_timeouts(self):
+        return self.timeouts
 
     def close(self):
         pass
@@ -75,6 +88,31 @@ class ConnectionTest(unittest.TestCase):
         assert response == 'this is a longer message'
 
     """
+    Test that the recv_msg method sets, and then clears the timeout.
+    """
+    def test_timeout(self):
+        self.conn.sock.add_response(3)
+        self.conn.sock.add_response('foo')
+        self.conn.sock.add_response('\0')
+
+        response = self.conn.recv_msg(1)
+        assert self.conn.sock.get_timeouts()[0] == 1
+        assert self.conn.sock.get_timeouts()[1] == None
+
+    """
+    Test that the recv_msg method clears the timeout even if there is a raise.
+    """
+    def test_timeout_finally(self):
+        self.conn.sock.add_raise(SocketMockError())
+
+        try:
+            response = self.conn.recv_msg(1)
+            assert False
+        except:
+            pass
+        assert self.conn.sock.get_timeouts()[1] == None
+
+    """
     Test that an EOFError is raised if the socket appears to be closed.
     """
     def test_read_eof(self):
@@ -90,3 +128,4 @@ class ConnectionTest(unittest.TestCase):
         self.conn.send_msg(cmd)
         sent = self.conn.sock.get_last_sent()
         assert sent == cmd+'\0'
+


### PR DESCRIPTION
Make Vdebug fully async - don't block VIM while stepping or running. This allows you to move around your source code, and if your debugging engine supports it, set breakpoints, break, or any supported operation while your code is running. As part of this change, I added support for break command in DBGP.

Justification: I normally debug programs which do not end. As such, without this change, should I not set a breakpoint I could hit by interacting with the program, I was forced to stop and restart the debugging engine to set new breakpoints. With this change, I can set a breakpoint I can hit while the program is not broken, so I can continue debugging.

Note: This is implemented against version 2. I have an implementation for version 1 if that is preferred.
