### PR TITLE
Implement support for DBGp Proxy servers

### DIFF
--- a/plugin/python/vdebug/runner.py
+++ b/plugin/python/vdebug/runner.py
@@ -323,8 +323,14 @@ class Runner:
                 if len(ide_key) == 0:
                     check_ide_key = False
 
-                connection = vdebug.dbgp.Connection(server,port,\
-                        timeout,vdebug.util.InputStream())
+                connection = vdebug.dbgp.Connection(
+                        server,
+                        port,
+                        vdebug.opts.Options.get('proxy_host'),
+                        vdebug.opts.Options.get('proxy_port',int),
+                        ide_key,
+                        timeout,
+                        vdebug.util.InputStream())
 
                 self.api = vdebug.dbgp.Api(connection)
                 if check_ide_key and ide_key != self.api.idekey:

--- a/plugin/vdebug.vim
+++ b/plugin/vdebug.vim
@@ -86,6 +86,8 @@ let g:vdebug_options_defaults = {
 \    "port" : 9000,
 \    "timeout" : 20,
 \    "server" : '',
+\    "proxy_host" : '',
+\    "proxy_port" : 9001,
 \    "on_close" : 'stop',
 \    "break_on_open" : 1,
 \    "ide_key" : '',


### PR DESCRIPTION
As documented here:
https://xdebug.org/docs-dbgp.php#just-in-time-debugging-and-debugger-proxies

Defines two new config parameters:
- proxy_host (default '')
- proxy_port (default 9001)

If both options are non-empty, the Connection class does a few new things at the beginning and end of our session.

New workflow when using a proxy is:
- VIM listens for debugger connections on local IP and port X (default=9000) like always
- VIM makes a connection to the proxy server on port Y (default=9001)
- VIM sends a "proxyinit" command, which includes ide_key and the port we are listening on (X)
- Proxy registers our IP/port with our ide_key and sends an XML response
- VIM processes the XML response and disconnects
- VIM starts the usual 20s wait for debugger connection
- debuggers are all hard-coded to connect to the proxy for debugging sessions
- If a debugger connection comes into the proxy (before the VIM timeout) with our ide_key, the proxy will connect back to us on port X and copy all data back and forth between VIM and debugger.  This connection is indistinguishable from a regular debugger connection (except originating from the proxy IP instead of the remote host IP).
- When we are done, VIM makes another connection to proxy port Y and sends a "proxystop" command to un-map our ide_key
