### PR TITLE
Vdebug crashes if Vim is running inside MSYS2

### DIFF
--- a/plugin/python/vdebug/msys2.py
+++ b/plugin/python/vdebug/msys2.py
@@ -1,0 +1,11 @@
+import vdebug.opts
+import platform
+
+def shell():
+    return platform.system()[:4] == 'MSYS'
+
+def toNativePath(path):
+    return path[1].upper() + ':' + path[2:].replace('/','\\')
+
+def toMSYSPath(path):
+    return '/' + path[0].lower() + path[2:].replace('\\','/')

--- a/plugin/python/vdebug/ui/vimui.py
+++ b/plugin/python/vdebug/ui/vimui.py
@@ -4,6 +4,7 @@ import vdebug.util
 import vim
 import vdebug.log
 import vdebug.opts
+import vdebug.msys2
 
 class Ui(vdebug.ui.interface.Ui):
     """Ui layer which manages the Vim windows.
@@ -104,7 +105,10 @@ class Ui(vdebug.ui.interface.Ui):
         self.statuswin.insert(details,1,True)
 
     def get_current_file(self):
-        return vdebug.util.LocalFilePath(vim.current.buffer.name)
+        if vdebug.msys2.shell():
+            return vdebug.util.LocalFilePath(vdebug.msys2.toNativePath(vim.current.buffer.name))
+        else:
+            return vdebug.util.LocalFilePath(vim.current.buffer.name)
 
     def get_current_row(self):
         return vim.current.window.cursor[0]
@@ -240,7 +244,11 @@ class SourceWindow(vdebug.ui.interface.Window):
         self.file = file
         vdebug.log.Log("Setting source file: "+file,vdebug.log.Logger.INFO)
         self.focus()
-        vim.command('call Vdebug_edit("%s")' % str(file).replace("\\", "\\\\"))
+
+        if vdebug.msys2.shell():
+            vim.command('call Vdebug_edit("%s")' % vdebug.msys2.toMSYSPath(str(file)))
+        else:
+            vim.command('call Vdebug_edit("%s")' % str(file).replace("\\", "\\\\"))
 
     def set_line(self,lineno):
         self.focus()
@@ -248,7 +256,10 @@ class SourceWindow(vdebug.ui.interface.Window):
 
     def get_file(self):
         self.focus()
-        self.file = vdebug.util.LocalFilePath(vim.eval("expand('%:p')"))
+        if vdebug.msys2.shell():
+            self.file = vdebug.util.LocalFilePath(vdebug.msys2.toNativePath(vim.eval("expand('%:p')")))
+        else:
+            self.file = vdebug.util.LocalFilePath(vim.eval("expand('%:p')"))
         return self.file
 
     def clear_signs(self):


### PR DESCRIPTION
This is for Vim running inside MSYS2.

MSYS2 uses a different path style than the Windows system it's running on.

`C:\foo\bar` becomes `/c/foo/bar`

The result is that Vdebug crashes upon incoming connection because Vim <-> Xdebug communication is broken.

This branch has some fixes for this situation on the Vim UI side of the code. It autodetects MSYS2 and applies style conversions if necessary.

I've just started using Vdebug so probably missed some stuff, but it seems to work for getting a connection, stepping through code with `<F2>`, `<F3>`, and working with breakpoints set with `<F10>`.
