### PR TITLE
counter mkexrc fileencoding behaviour

### DIFF
--- a/pythonx/vdebug/util.py
+++ b/pythonx/vdebug/util.py
@@ -6,7 +6,6 @@ import socket
 import sys
 import time
 import traceback
-import codecs
 try:
     import urllib.parse as urllib
 except ImportError:
@@ -157,9 +156,9 @@ class Keymapper:
         keys = {v for k, v in self.keymaps.items() if k not in self.exclude}
         special = {"<buffer>", "<silent>", "<special>", "<script>", "<expr>",
                    "<unique>"}
-        for line in codecs.open(tempfile, 'r', errors='ignore'):
+        for line in open(tempfile, 'rb'):
+            line = line.decode('utf-8', errors='replace')
             log.Log("keymapper: line '%s'" % line, log.Logger.DEBUG)
-            line = line.encode('utf-8').decode('utf-8')
             if not regex.match(line):
                 continue
             parts = split_regex.split(line)[1:]


### PR DESCRIPTION
mkexrc writes the exrc file with an encoding detected somewhere through
your vimrc file, ...  With a properly encoded vimrc and such you get a
nice utf-8 file, with some vimrc's there is some mixing which causes the
mkexrc command to write the exrc file with latin1 or cp1250 or ...

Now the reading of the temporary exrc file is done binary and the
strings are converted back to utf-8 using the replace strategy. This
should make sure we don't get Unicode errors while reading the file
searching for maps that need replacing for proper functioning of vdebug.

fixes #350

Signed-off-by: BlackEagle <ike.devolder@gmail.com>