### PR TITLE
use double quote around property in property_get

### DIFF
--- a/pythonx/vdebug/dbgp.py
+++ b/pythonx/vdebug/dbgp.py
@@ -360,8 +360,11 @@ class Api:
     def property_get(self, name):
         """Get a property.
         """
-        return self.send_cmd('property_get', '-n %s -d 0' % name,
-                             ContextGetResponse)
+        return self.send_cmd(
+            'property_get',
+            '-n "%s" -d 0' % name.replace("\\", "\\\\").replace("\"", "\\\""),
+            ContextGetResponse
+        )
 
     def detach(self):
         """Tell the debugger to detach itself from this


### PR DESCRIPTION
Some debuggers don't like you just sending obj['subobj']. The possible
response you get there is that the property is not found. Refering to
the dbgp documentation we an also send the property_get command with the
property between double qoutes, but that implicates we must escape
backslashes and double quotes.

Fixes #312

Signed-off-by: BlackEagle <ike.devolder@gmail.com>