### PR TITLE
Fix wrong Github path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vdebug
 
-[![Build Status](https://travis-ci.org/joonty/vdebug.png?branch=master)](https://travis-ci.org/joonty/vdebug)
+[![Build Status](https://travis-ci.org/vim-vdebug/vdebug.png?branch=master)](https://travis-ci.org/vim-vdebug/vdebug)
 
 ## Introduction
 
@@ -36,7 +36,7 @@ The actual installation is no different than for any other Vim plugin, you can
   `:call pathogen#helptags()` afterwards.
 * use your favorite plugin manager: Put the respective instruction in your init
   file and update your plugins afterwards.  For Vundle this would be `Plugin
-  'joonty/vdebug'` and `:PluginInstall`.
+  'vim-vdebug/vdebug'` and `:PluginInstall`.
 
 ### Python 2
 
@@ -132,8 +132,8 @@ directory of the plugin
 
 This plugin is released under the [MIT License][1].
 
-[1]: https://raw.github.com/joonty/vdebug/master/LICENCE
+[1]: https://raw.github.com/vim-vdebug/vdebug/master/LICENCE
 [2]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
-[3]: https://github.com/joonty/vdebug/issues/
-[4]: https://github.com/joonty/vdebug/issues/new
-[5]: https://github.com/joonty/vdebug/releases/tag/v1.5.2
+[3]: https://github.com/vim-vdebug/vdebug/issues/
+[4]: https://github.com/vim-vdebug/vdebug/issues/new
+[5]: https://github.com/vim-vdebug/vdebug/releases/tag/v1.5.2

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -90,7 +90,7 @@ catch
 endtry
 
 Plugin 'gmarik/Vundle.vim'
-Plugin 'joonty/vdebug.git'
+Plugin 'vim-vdebug/vdebug.git'
 
 call vundle#end()
 
@@ -147,7 +147,7 @@ echo "export LANG=en_US.UTF-8" >> /home/vagrant/.bashrc
 echo "export DISPLAY=:0" >> /home/vagrant/.bashrc
 mkdir -p /home/vagrant/.vim-tmp /home/vagrant/.vim/bundle
 git clone https://github.com/gmarik/Vundle.vim.git ~/.vim/bundle/Vundle.vim
-git clone https://github.com/joonty/vdebug.git ~/.vim/bundle/vdebug
+git clone https://github.com/vim-vdebug/vdebug.git ~/.vim/bundle/vdebug
 cd /vagrant
 bundle install
 EOF

--- a/doc/Vdebug.txt
+++ b/doc/Vdebug.txt
@@ -149,8 +149,8 @@ compiled with tabs, signs and Python 3 support. If you're using Windows, some
 reports have said that Python must be installed separately to allow VIM to use
 it.
 
-The Github page for the plugin is https://github.com/joonty/vdebug, and the VIM
-scripts URL is http://www.vim.org/scripts/script.php?script_id=4170.
+The Github page for the plugin is https://github.com/vim-vdebug/vdebug, and the
+VIM scripts URL is https://www.vim.org/scripts/script.php?script_id=4170.
 
 By far the easiest way to install is by using a plugin manager, e.g. vundle
 (https://github.com/gmarik/vundle/) or pathogen
@@ -780,7 +780,7 @@ some debugger engines.
 4.6 Tracing expressions                                          *VdebugTrace*
 
 A large part of this work is thanks to escher9 on Github. See this pull
-request for the history: https://github.com/joonty/vdebug/pull/178.
+request for the history: https://github.com/vim-vdebug/vdebug/pull/178
 
 If you want to track an expression (any piece of code that can be evaluated)
 or clearly see how a single variable changes through your code's execution,
@@ -1117,9 +1117,9 @@ machine using your router, as it will be blocked by default.
 10. Troubleshooting/FAQ                                *VdebugTroubleshooting*
 
 If you have any questions or problems that aren't addressed or fixed here then
-feel free to raise an issue on the Github page https://github.com/joonty/vdebug
-or email me at <jon AT joncairns.com>. If the question is good I might even add
-it to this list.
+feel free to raise an issue on the Github page
+https://github.com/vim-vdebug/vdebug or email me at <jon AT joncairns.com>. If
+the question is good I might even add it to this list.
 
     Q. I can't get the debugger to run! Pressing <F5> does nothing.
     A. The most common reason for this is that your VIM installation is not

--- a/plugin/vdebug.vim
+++ b/plugin/vdebug.vim
@@ -13,7 +13,8 @@
 "               Seung Woo Shin <segv <at> sayclub.com> and extended by many
 "               others.
 "        Usage: Use :help Vdebug for information on how to configure and use
-"               this script, or visit the Github page http://github.com/joonty/vdebug.
+"               this script, or visit the Github page
+"               https://github.com/vim-vdebug/vdebug.
 "
 "=============================================================================
 " }}}


### PR DESCRIPTION
Since the procject was renamed from joonty/vdebug to vim-vdebug/vdebug, some
paths should be updated.
Bonus: this will also fix the Travis build badge in the README.md

I've blindly searched'n'replaced 'joonty' by 'vim-vdebug'  via
`find . -type f -exec sed -i -e 's/joonty/vim-vdebug/g' {} \;`
and made manual changes if necessary (such as formatting and HTTPS'ing URLs).