### PR TITLE
Update documentation for continuous_mode option to align with reality

### DIFF
--- a/doc/Vdebug.txt
+++ b/doc/Vdebug.txt
@@ -960,7 +960,7 @@ g:vdebug_options.marker_open_tree (default = '▾')
     byte support is not enabled.
 
                                               *VdebugOptions-continuous_mode*
-g:vdebug_options.continuous_mode (default = 0)
+g:vdebug_options.continuous_mode (default = 1)
     If enabled, Vdebug will start listening immediately after a debugging
     session has finished, allowing for constant debugging across separate
     requests. Press <F6> during a debugging session to stop this, or <Ctrl-C>


### PR DESCRIPTION
The documentation states that the default for continuous_mode is 0, when it is in fact 1.

Either the documentation should change or the default should change. I opted to update the documentation as to not break existing install expectations.