### PR TITLE
Handled UnicodeDecodeError on invalid string value

### DIFF
--- a/python3/vdebug/dbgp.py
+++ b/python3/vdebug/dbgp.py
@@ -420,8 +420,11 @@ class ContextProperty:
                 if node.text is None:
                     self.value = ""
                 else:
-                    self.value = base64.decodebytes(
-                        node.text.encode("UTF-8")).decode("utf-8")
+                    try:
+                        self.value = base64.decodebytes(
+                            node.text.encode("UTF-8")).decode("utf-8")
+                    except UnicodeDecodeError:
+                        self.value = node.text
             elif not self.is_uninitialized() and not self.has_children:
                 self.value = node.text
 

--- a/tests/test_dbgp_eval_property.py
+++ b/tests/test_dbgp_eval_property.py
@@ -37,3 +37,15 @@ class EvalPropertyTest(unittest.TestCase):
 
         self.assertEqual(prop.children[1].type,'array')
         self.assertEqual(prop.children[1].display_name,"$testarr['key']")
+
+    def test_non_unicode_value(self):
+        prop = self.__get_eval_property(\
+            """<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" command="context_get" transaction_id="8" context="0">
+    <property name="$value" fullname="$value" type="string" size="68" encoding="base64"><![CDATA[AAAAAAHa86Gey+29BQAKYWJ1c2VIOWU0MzI5NjEtMzg5Zi00NmJiLWEwZDUtZDM4MGI1ODY5YzRinsCwBJzAsASSpHM=]]></property>
+</response>
+""", '$value', 'php')
+
+        self.assertEqual(prop.display_name,'$value')
+        self.assertEqual(len(prop.value),94)
+        self.assertEqual(prop.type,'string')


### PR DESCRIPTION
While debugging code that contains serialized [avro](https://avro.apache.org/docs/1.8.2/spec.html) output, I was getting a `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte` error.

It appears that this is normal as the bytes string generated by avro is not meant to represent unicode characters.

This PR fixes the issue by setting the raw value whenever the error is encountered.

NB: I am not efficient in python, as well as in vim plugin development. Let me know if I can improve this PR by adding some tests, and if so please point out an example :) 