### PR TITLE
add view preset where you can choose debugger layout

### DIFF
--- a/doc/Vdebug.txt
+++ b/doc/Vdebug.txt
@@ -852,7 +852,9 @@ The default options look like this: >
     \    'marker_open_tree' : '▾',
     \    'sign_breakpoint' : '▷',
     \    'sign_current' : '▶',
-    \    'continuous_mode'  : 1
+    \    'continuous_mode'  : 1,
+    \    'simplified_status': 1,
+    \    'view_preset': 'vertical',
     \}
 <
 You can either use the multi-line notation like above, or set individual keys
@@ -975,6 +977,51 @@ g:vdebug_options.continuous_mode (default = 1)
     session has finished, allowing for constant debugging across separate
     requests. Press <F6> during a debugging session to stop this, or <Ctrl-C>
     when Vdebug is listening.
+
+g:vdebug_options.simplified_status (default = 1)
+    When enabled the status will be shown in 1 line, if disabled you get a more
+    verbose status output
+
+g:vdebug_options.view_preset (default = 'vertical')
+    When view preset is vertical, the debug session tab will have a vertical
+    split between the source window and the DebuggerStatus, DebuggerStack and
+    DebuggerWatch.
+
+    +------------------------------------+-----------------------------------+
+    |                                    |    DebuggerStatus                 |
+    |                                    +-----------------------------------+
+    |                                    |    DebuggerStack                  |
+    |                                    |                                   |
+    |                                    |                                   |
+    |      SourceWindow                  +-----------------------------------+
+    |                                    |    DebuggerWatch                  |
+    |                                    |                                   |
+    |                                    |                                   |
+    |                                    |                                   |
+    |                                    |                                   |
+    |                                    |                                   |
+    |                                    |                                   |
+    +------------------------------------+-----------------------------------+
+
+    When the view preset is horizontal, the debug session tab will have a
+    horizontal split between the source window and the DebuggerStatus and
+    DebuggerStack will be split on the left next to the DebuggerWatch.
+
+    +------------------------------------------------------------------------+
+    |                                                                        |
+    |                                                                        |
+    |                                                                        |
+    |                              SourceWindow                              |
+    |                                                                        |
+    |                                                                        |
+    |                                                                        |
+    |                                                                        |
+    +------------------------------------+-----------------------------------+
+    |    DebuggerStatus                  |                                   |
+    +------------------------------------+    DebuggerWatch                  |
+    |    DebuggerStack                   |                                   |
+    |                                    |                                   |
+    +------------------------------------+-----------------------------------+
 
 ==============================================================================
 6. Key maps                                                       *VdebugKeys*

--- a/plugin/vdebug.vim
+++ b/plugin/vdebug.vim
@@ -94,8 +94,23 @@ let g:vdebug_options_defaults = {
 \    'background_listener' : 1,
 \    'auto_start' : 1,
 \    'simplified_status': 1,
+\    'view_preset': 'vertical',
+\}
+
+let g:vdebug_layout_vertical = {
 \    'window_commands' : {
-\        'DebuggerWatch' : 'below new',
+\        'DebuggerWatch' : 'vertical belowright new',
+\        'DebuggerStack' : 'aboveleft 12new',
+\        'DebuggerStatus' : 'aboveleft 1new'
+\    },
+\    'window_size': {
+\    },
+\    'window_arrangement' : ['DebuggerWatch', 'DebuggerStack', 'DebuggerStatus']
+\}
+
+let g:vdebug_layout_horizontal = {
+\    'window_commands' : {
+\        'DebuggerWatch' : 'below 15new',
 \        'DebuggerStack' : 'belowright new',
 \        'DebuggerStatus' : 'vertical leftabove new'
 \    },
@@ -176,6 +191,12 @@ endfunction
 function! Vdebug_load_options(options)
     " Merge options with defaults
     let g:vdebug_options = extend(g:vdebug_options_defaults, a:options)
+
+    if g:vdebug_options['view_preset'] == 'horizontal'
+        let g:vdebug_options = extend(g:vdebug_options, g:vdebug_layout_horizontal)
+    else
+        let g:vdebug_options = extend(g:vdebug_options, g:vdebug_layout_vertical)
+    endif
 
     " Override with single defined params ie. g:vdebug_options_port
     let single_defined_params = s:Vdebug_get_options()


### PR DESCRIPTION
Add a horizontal and vertical view_preset where you can choose your
debugging experience layout.

Vertical:

  +------------------------------------+-----------------------------------+
  |                                    |    DebuggerStatus                 |
  |                                    +-----------------------------------+
  |                                    |    DebuggerStack                  |
  |                                    |                                   |
  |                                    |                                   |
  |      SourceWindow                  +-----------------------------------+
  |                                    |    DebuggerWatch                  |
  |                                    |                                   |
  |                                    |                                   |
  |                                    |                                   |
  |                                    |                                   |
  |                                    |                                   |
  |                                    |                                   |
  +------------------------------------+-----------------------------------+

Horizontal:

  +------------------------------------------------------------------------+
  |                                                                        |
  |                                                                        |
  |                                                                        |
  |                              SourceWindow                              |
  |                                                                        |
  |                                                                        |
  |                                                                        |
  |                                                                        |
  +------------------------------------+-----------------------------------+
  |    DebuggerStatus                  |                                   |
  +------------------------------------+    DebuggerWatch                  |
  |    DebuggerStack                   |                                   |
  |                                    |                                   |
  +------------------------------------+-----------------------------------+

By just adding the following to your vimrc you get one of the layouts

vertical:

``` vim
let g:vdebug_options = {
    \'view_preset': 'vertical'
\}
```

horizontal:

``` vim
let g:vdebug_options = {
    \'view_preset': 'horizontal'
\}
```

Signed-off-by: BlackEagle <ike.devolder@gmail.com>