### PR TITLE
when coming back from eval, pass context 0 to the event

### DIFF
--- a/python3/vdebug/debugger_interface.py
+++ b/python3/vdebug/debugger_interface.py
@@ -147,7 +147,7 @@ class DebuggerInterface:
     def get_context(self):
         """Get all the variables in the default context
         """
-        self.session_handler.dispatch_event("get_context")
+        self.session_handler.dispatch_event("get_context", 0)
 
     def detach(self):
         """Detach the debugger, so the script runs to the end.


### PR DESCRIPTION
this will return us to the local variables context from the eval.

fixes #395

Signed-off-by: BlackEagle <ike.devolder@gmail.com>