### PR TITLE
first check connection before detaching

### DIFF
--- a/python3/vdebug/session.py
+++ b/python3/vdebug/session.py
@@ -222,8 +222,10 @@ class Session:
     def detach(self):
         """Detach the debugger engine, and allow it to continue execution.
         """
-        self.__ui.say("Detaching the debugger")
-        self.__api.detach()
+        if self.is_connected():
+            self.__ui.say("Detaching the debugger")
+            self.__api.detach()
+
         self.close_connection(False)
 
     def __set_features(self):


### PR DESCRIPTION
When there is no connection and you were detaching you just got a
stacktrace. So first check if there is an actual connection to detach
from.

Signed-off-by: BlackEagle <ike.devolder@gmail.com>