### PR TITLE
Fix #423 - Vim Hangs on exit if vdebug is running.

### DIFF
--- a/plugin/vdebug.vim
+++ b/plugin/vdebug.vim
@@ -314,6 +314,8 @@ function! Vdebug_statusline()
 endfunction
 
 augroup Vdebug
+augroup END
+augroup VdebugOut
 autocmd VimLeavePre * python3 debugger.close()
 augroup END
 


### PR DESCRIPTION
Assign a seperate autocmd group to VimLeavePre to prevent it being erased by the listener.