### PR TITLE
Jump from breakpoint window to breakpoint in source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ vendor/
 .bash_history
 Gemfile.lock
 .gem/
+tags

--- a/python3/vdebug/debugger_interface.py
+++ b/python3/vdebug/debugger_interface.py
@@ -147,6 +147,11 @@ class DebuggerInterface:
         """
         self.session_handler.dispatch_event("remove_breakpoint", args)
 
+    def jump_breakpoint(self, args=None):
+        """Jump to a breakpoint in the source window from the breakpoint window
+        """
+        self.session_handler.dispatch_event("breakpoint_jump", args)
+
     def get_context(self):
         """Get all the variables in the default context
         """

--- a/python3/vdebug/ui/vimui.py
+++ b/python3/vdebug/ui/vimui.py
@@ -620,6 +620,10 @@ class BreakpointWindow(Window):
     def on_create(self):
         if self.creation_count == 1:
             self.insert(self.header, 0)
+        self.command('inoremap <buffer> <cr> <esc>'
+                     ':python3 debugger.handle_return_keypress()<cr>')
+        self.command('nnoremap <buffer> <cr> '
+                     ':python3 debugger.handle_return_keypress()<cr>')
         self.command('setlocal syntax=debugger_breakpoint')
 
     def add_breakpoint(self, breakpoint):


### PR DESCRIPTION
There seems to be a small bug that whenever the stack contains only one item, the jumping does not work. This is also the case for the stack jump.

#442 