### PR TITLE
Close quietly when exiting vim

### DIFF
--- a/plugin/vdebug.vim
+++ b/plugin/vdebug.vim
@@ -324,7 +324,7 @@ endfunction
 augroup Vdebug
 augroup END
 augroup VdebugOut
-autocmd VimLeavePre * python3 debugger.close()
+autocmd VimLeavePre * python3 debugger.quit()
 augroup END
 
 call Vdebug_load_options(g:vdebug_options)

--- a/python3/vdebug/debugger_interface.py
+++ b/python3/vdebug/debugger_interface.py
@@ -179,3 +179,8 @@ class DebuggerInterface:
         """Close the connection, or the UI if already closed.
         """
         self.session_handler.stop()
+
+    def quit(self):
+        """Close the connection, or the UI if already closed. On Exit
+        """
+        self.session_handler.stop(quiet=True)

--- a/python3/vdebug/session.py
+++ b/python3/vdebug/session.py
@@ -64,7 +64,7 @@ class SessionHandler:
         else:
             self.listen()
 
-    def stop(self):
+    def stop(self, quiet=False):
         if self.is_connected():
             self.__session.close_connection()
         elif self.is_listening():
@@ -72,7 +72,8 @@ class SessionHandler:
         elif self.is_open():
             self.__ui.close()
         else:
-            self.__ui.say("Vdebug is not running")
+            if False is quiet:
+                self.__ui.say("Vdebug is not running")
 
     def close(self):
         self.stop_listening()


### PR DESCRIPTION
This will stop showning "Vdebug is not running" when quiting vim. If
Vdebug was running it will just silently close it so we can properly
exit vim.

Signed-off-by: BlackEagle <ike.devolder@gmail.com>