### PR TITLE
Handle TypeError in event.py

### DIFF
--- a/python3/vdebug/event.py
+++ b/python3/vdebug/event.py
@@ -274,7 +274,10 @@ class RefreshEvent(Event):
 
     def run(self, status):
 
-        status_str = str(status)
+        try:
+            status_str = str(status)
+        except TypeError:
+            return
 
         if not status_str:
             return


### PR DESCRIPTION
Hi there, many thanks for this great vim plugin :tada: 

I often see errors like this one:
```
- [ERROR] {Thu 16 2020 12:36:05} An error occured: <class 'TypeError'>
Traceback (most recent call last):
  File "/home/abez/.vim/plugged/vdebug/python3/vdebug/event.py", line 781, in dispatch_event
    Dispatcher.events[name](self.__session_handler).run(*args)
  File "/home/abez/.vim/plugged/vdebug/python3/vdebug/event.py", line 277, in run
    status_str = str(status)
TypeError: __str__ returned non-string (type NoneType)
```

or:
```
Error detected while processing FocusGained Autocommands for "*":
An error occured: <class 'TypeError'>
Traceback (most recent call last):
  File "/home/abez/.vim/plugged/vdebug/python3/vdebug/event.py", line 781, in dispatch_event
    Dispatcher.events[name](self.__session_handler).run(*args)
  File "/home/abez/.vim/plugged/vdebug/python3/vdebug/event.py", line 277, in run
    status_str = str(status)
TypeError: __str__ returned non-string (type NoneType)
```

This was annoying enough to create this patch, which works for me. I'm not programming in python for > 8 years, so there might be a better solution to that.

I hope that this will fix the following issues:
* #345
* #434
* #457

Not sure if this is related to these issues:
* #147
* #223
* #362