### PR TITLE
allow to manually force ascii if needed

### DIFF
--- a/plugin/vdebug.vim
+++ b/plugin/vdebug.vim
@@ -34,14 +34,16 @@ if !has('python3')
     finish
 endif
 
-" Nice characters get screwed up on windows
-if has('win32') || has('win64')
-    let g:vdebug_force_ascii = 1
-elseif has('multi_byte') == 0
-    let g:vdebug_force_ascii = 1
-else
-    let g:vdebug_force_ascii = 0
-end
+if !exists('g:vdebug_force_ascii')
+    " Nice characters get screwed up on windows
+    if has('win32') || has('win64')
+        let g:vdebug_force_ascii = 1
+    elseif has('multi_byte') == 0
+        let g:vdebug_force_ascii = 1
+    else
+        let g:vdebug_force_ascii = 0
+    end
+endif
 
 if !exists('g:vdebug_options')
     let g:vdebug_options = {}


### PR DESCRIPTION
Allow to set g:vdebug_force_ascii in your configuration to allow
skipping the use of unicode glyphs. Before this was always set
automatically.

related #468

Signed-off-by: BlackEagle <ike.devolder@gmail.com>