### PR TITLE
add default feature set of some features

### DIFF
--- a/python3/vdebug/connection.py
+++ b/python3/vdebug/connection.py
@@ -81,7 +81,7 @@ class ConnectionHandler:
 
         cmd -- command to send
         """
-        #self.sock.send(cmd + '\0')
+        # self.sock.send(cmd + '\0')
         MSGLEN = len(cmd)
         totalsent = 0
         while totalsent < MSGLEN:


### PR DESCRIPTION
If we look at https://xdebug.org/docs/dbgp#options-and-configuration in
the feature names we see any dbgp debugger must provide some feature set
by default. Even if that feature is not actually supported.

So from now on we will set multiple_sessions = 0 because Vdebug does not
support this at the moment and we will try to set extended_properties =
1; if the used debugger does not support it we will silently continue
without the feature.

fixes #369

Signed-off-by: BlackEagle <ike.devolder@gmail.com>