### PR TITLE
docs: fix simple typo, detatch -> detach

### DIFF
--- a/tests/test_dbgp_api.py
+++ b/tests/test_dbgp_api.py
@@ -127,10 +127,10 @@ class ApiTest(unittest.TestCase):
         assert str(status_res) == "stopping"
 
     def test_detatch_retval(self):
-        """Test that the detatch command receives a message from the api."""
+        """Test that the detach command receives a message from the api."""
         self.p.conn.recv_msg.return_value = """<?xml
             version="1.0" encoding="iso-8859-1"?>\n
-            <response command="detatch"
+            <response command="detach"
                       xmlns="urn:debugger_api_v1"
                       status="stopped"
                       reason="ok"


### PR DESCRIPTION
There is a small typo in tests/test_dbgp_api.py.

Should read `detach` rather than `detatch`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md