### PR TITLE
Add dbgpproxy support

### DIFF
--- a/plugin/vdebug.vim
+++ b/plugin/vdebug.vim
@@ -79,6 +79,8 @@ let g:vdebug_options_defaults = {
 \    'port' : 9000,
 \    'timeout' : 20,
 \    'server' : '',
+\    "proxy_host" : '',
+\    "proxy_port" : 9001,
 \    'on_close' : 'stop',
 \    'break_on_open' : 1,
 \    'ide_key' : '',

--- a/python3/vdebug/connection.py
+++ b/python3/vdebug/connection.py
@@ -130,7 +130,6 @@ class SocketCreator:
                 self.proxyinit(proxy_host, proxy_port, port, idekey)
             self.__sock = self.accept(serv, timeout)
         except socket.timeout:
-            self.proxystop()
             raise TimeoutError("Timeout waiting for connection")
         finally:
             self.proxystop(proxy_host, proxy_port, idekey)
@@ -251,7 +250,6 @@ class BackgroundSocketCreator(threading.Thread):
                     # No connection
                     pass
         except socket.error as socket_error:
-            await self.proxystop()
             self.log("Error: %s" % str(sys.exc_info()))
             self.log("Stopping server")
 
@@ -259,11 +257,9 @@ class BackgroundSocketCreator(threading.Thread):
                 self.log("Address already in use")
                 print("Socket is already in use")
         except asyncio.CancelledError as e:
-            await self.proxystop()
             self.log("Stopping server")
             self.__socket_task = None
         except Exception as e:
-            await self.proxystop()
             print("Exception caught")
             self.log("Error: %s" % str(sys.exc_info()))
             self.log("Stopping server")

--- a/python3/vdebug/listener.py
+++ b/python3/vdebug/listener.py
@@ -22,6 +22,9 @@ class ForegroundListener:
     def start(self):
         self.__server.start(opts.Options.get('server'),
                             opts.Options.get('port', int),
+                            opts.Options.get('proxy_host'),
+                            opts.Options.get('proxy_port', int),
+                            opts.Options.get('ide_key'),
                             opts.Options.get('timeout', int))
 
     def stop(self):
@@ -51,7 +54,10 @@ class BackgroundListener:
         if opts.Options.get("auto_start", int):
             vim.command('autocmd Vdebug CursorHold,CursorHoldI,CursorMoved,CursorMovedI,FocusGained,FocusLost * python3 debugger.start_if_ready()')
         self.__server.start(opts.Options.get('server'),
-                            opts.Options.get('port', int))
+                            opts.Options.get('port', int),
+                            opts.Options.get('proxy_host'),
+                            opts.Options.get('proxy_port', int),
+                            opts.Options.get('ide_key'))
 
     def stop(self):
         if opts.Options.get("auto_start", bool):


### PR DESCRIPTION
Recovering the pull request done by @staticglobal in https://github.com/vim-vdebug/vdebug/pull/237 , it does what  was doing but refactoring code to be used in v2 .
 
Quoting original contribution:
> As documented here: https://xdebug.org/docs-dbgp.php#just-in-time-debugging-and-debugger-proxies
> 
> Defines two new config parameters:
> 
>     * proxy_host (default '')
> 
>     * proxy_port (default 9001)
> 
> 
> If both options are non-empty, the Connection class does a few new things at the beginning and end of our session.
> 
> New workflow when using a proxy is:
> 
>     * VIM listens for debugger connections on local IP and port X (default=9000) like always
> 
>     * VIM makes a connection to the proxy server on port Y (default=9001)
> 
>     * VIM sends a "proxyinit" command, which includes ide_key and the port we are listening on (X)
> 
>     * Proxy registers our IP/port with our ide_key and sends an XML response
> 
>     * VIM processes the XML response and disconnects
> 
>     * VIM starts the usual 20s wait for debugger connection
> 
>     * debuggers are all hard-coded to connect to the proxy for debugging sessions
> 
>     * If a debugger connection comes into the proxy (before the VIM timeout) with our ide_key, the proxy will connect back to us on port X and copy all data back and forth between VIM and debugger.  This connection is indistinguishable from a regular debugger connection (except originating from the proxy IP instead of the remote host IP).
> 
>     * When we are done, VIM makes another connection to proxy port Y and sends a "proxystop" command to un-map our ide_key

