### PR TITLE
Fix TypeError: can only concatenate str (not "NoneType") to str

### DIFF
--- a/python3/vdebug/dbgp.py
+++ b/python3/vdebug/dbgp.py
@@ -533,16 +533,19 @@ class EvalProperty(ContextProperty):
             self.display_name = self.code
         else:
             if self.language == 'php':
+                name = node.get('name')
+                if not isinstance(name, str):
+                    name = self._get_enc_node_text(node, 'name', "")
                 if self.parent.type == 'array':
-                    if node.get('name').isdigit():
+                    if name.isdigit():
                         self.display_name = self.parent.display_name + \
-                            "[%s]" % node.get('name')
+                            "[%s]" % name
                     else:
                         self.display_name = self.parent.display_name + \
-                            "['%s']" % node.get('name')
+                            "['%s']" % name
                 else:
                     self.display_name = self.parent.display_name + \
-                        "->" + node.get('name')
+                        "->" + name
             elif self.language == 'perl':
                 self.display_name = node.get('fullname')
             else:


### PR DESCRIPTION
On some variable inspection I get:
An error occured: <class 'TypeError'>
Traceback (most recent call last):
File "/home/tavy/.vim/plugged/vdebug/python3/vdebug/event.py", line 784, in dispatch_event
Dispatcher.events[name](https://github.com/vim-vdebug/vdebug/pull/self.__session_handler).run(*args)
File "/home/tavy/.vim/plugged/vdebug/python3/vdebug/event.py", line 411, in run
self.ui.windows.watch().accept_renderer(rend)
File "/home/tavy/.vim/plugged/vdebug/python3/vdebug/ui/vimui.py", line 619, in accept_renderer
self.write(renderer.render())
File "/home/tavy/.vim/plugged/vdebug/python3/vdebug/ui/vimui.py", line 910, in render
properties = self.response.get_context()
File "/home/tavy/.vim/plugged/vdebug/python3/vdebug/dbgp.py", line 150, in get_context
self.create_properties(EvalProperty(c, code, self.api.language))
TypeError: can only concatenate str (not "NoneType") to str